### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -5,3 +5,4 @@
 
 # Fixes
 - Rename enricher configuration api key field
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.OpenCorporates/Constants.cs
+++ b/src/ExternalSearch.Providers.OpenCorporates/Constants.cs
@@ -50,7 +50,6 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             public const string TargetApiKey = "targetApiKey";
             public const string AcceptedEntityType = "acceptedEntityType";
             public const string LookupVocabularyKey = "lookupVocabularyKey";
-            public const string SkipCompanyNumberEntityCodeCreation = "skipCompanyNumberEntityCodeCreation";
         }
 
         public static string About { get; set; } = "Open Corporates is an enricher which provides information on all companies worldwide";
@@ -75,14 +74,6 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
                 Name = KeyName.LookupVocabularyKey,
                 Help = "The vocabulary key that contains the names of companies you want to enrich (e.g., organization.name)."
             },
-            new()
-            {
-                DisplayName = $"Skip {Core.Constants.DomainLabels.EntityCode} Creation (Company Number)",
-                Type = "checkbox",
-                IsRequired = false,
-                Name = KeyName.SkipCompanyNumberEntityCodeCreation,
-                Help = $"Toggle to control the creation of new {Core.Constants.DomainLabels.EntityCodes.ToLower()} using the Company Number."
-            }
         };
 
         public static AuthMethods AuthMethods { get; set; } = new AuthMethods

--- a/src/ExternalSearch.Providers.OpenCorporates/OpenCorporatesExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.OpenCorporates/OpenCorporatesExternalSearchJobData.cs
@@ -11,7 +11,6 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             TargetApiKey = GetValue<string>(configuration, KeyName.TargetApiKey, default(string));
             AcceptedEntityType = GetValue(configuration, KeyName.AcceptedEntityType, default(string));
             LookupVocabularyKey = GetValue<string>(configuration, KeyName.LookupVocabularyKey, default(string));
-            SkipCompanyNumberEntityCodeCreation = GetValue(configuration, KeyName.SkipCompanyNumberEntityCodeCreation, default(bool));
         }
 
         public IDictionary<string, object> ToDictionary()
@@ -21,12 +20,10 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
                 { KeyName.TargetApiKey, TargetApiKey },
                 { KeyName.AcceptedEntityType, AcceptedEntityType },
                 { KeyName.LookupVocabularyKey, LookupVocabularyKey },
-                { KeyName.SkipCompanyNumberEntityCodeCreation, SkipCompanyNumberEntityCodeCreation },
             };
         }     
 
         public string AcceptedEntityType { get; set; }
         public string LookupVocabularyKey { get; set; }
-        public bool SkipCompanyNumberEntityCodeCreation { get; set; }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#47706v

Topology now showing OpenCorporates data, but the one from other enricher turn into no source
![image](https://github.com/user-attachments/assets/5e63bac5-8683-44fa-9cf2-317610fa172c)

## How has it been tested? <!-- Remove if not needed -->
Manually in local

