### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,13 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +23,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.OpenCorporates.Provider/Provider.ExternalSearch.OpenCorporates.csproj
+++ b/src/ExternalSearch.Providers.OpenCorporates.Provider/Provider.ExternalSearch.OpenCorporates.csproj
@@ -3,7 +3,6 @@
   
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.OpenCorporates/ExternalSearch.Providers.OpenCorporates.csproj
+++ b/src/ExternalSearch.Providers.OpenCorporates/ExternalSearch.Providers.OpenCorporates.csproj
@@ -10,7 +10,4 @@
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
   </ItemGroup>
-  <PropertyGroup>
-	<LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.OpenCorporates/NewtonsoftJsonSerializer.cs
+++ b/src/ExternalSearch.Providers.OpenCorporates/NewtonsoftJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NewtonsoftJsonSerializer.cs" company="Clued In">
 //   Copyright (c) 2019 Clued In. All rights reserved.
 // </copyright>
@@ -11,12 +11,12 @@ using System.IO;
 
 using Newtonsoft.Json;
 
-using RestSharp.Deserializers;
+using RestSharp;
 using RestSharp.Serializers;
 
 namespace CluedIn.ExternalSearch.Providers.OpenCorporates
 {
-    public class NewtonsoftJsonSerializer : ISerializer, IDeserializer
+    public class NewtonsoftJsonSerializer : IRestSerializer, ISerializer, IDeserializer
     {
         private readonly Newtonsoft.Json.JsonSerializer serializer;
 
@@ -25,17 +25,20 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             this.serializer = serializer;
         }
 
-        public string ContentType
-        {
-            get { return "application/json"; }
-            set { }
-        }
+        public ContentType ContentType { get; set; } = ContentType.Json;
 
         public string DateFormat { get; set; }
 
         public string Namespace { get; set; }
 
         public string RootElement { get; set; }
+
+        public ISerializer Serializer => this;
+        public IDeserializer Deserializer => this;
+
+        public string[] AcceptedContentTypes => ContentType.JsonAccept;
+        public SupportsContentType SupportsContentType => contentType => contentType.Value.EndsWith("json", System.StringComparison.InvariantCultureIgnoreCase);
+        public DataFormat DataFormat => DataFormat.Json;
 
         public string Serialize(object obj)
         {
@@ -50,7 +53,9 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             }
         }
 
-        public T Deserialize<T>(RestSharp.IRestResponse response)
+        public string Serialize(Parameter parameter) => Serialize(parameter.Value);
+
+        public T Deserialize<T>(RestResponse response)
         {
             var content = response.Content;
 

--- a/src/ExternalSearch.Providers.OpenCorporates/OpenCorporatesExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.OpenCorporates/OpenCorporatesExternalSearchProvider.cs
@@ -134,12 +134,11 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             if (nameLookup == null && jurisdictionCodeLookup.Value == null)
                 yield break;
 
-            var client = new RestClient("https://api.opencorporates.com/v0.4");
-            client.AddHandler("application/json", () => NewtonsoftJsonSerializer.Default);
+            var client = new RestClient(new RestClientOptions("https://api.opencorporates.com/v0.4"), configureSerialization: s => s.UseSerializer(() => NewtonsoftJsonSerializer.Default));
 
             var request = !string.IsNullOrEmpty(nameLookup)
-                ? new RestRequest($"/companies/search?q={nameLookup}", Method.GET) // This will return a sparse company result
-                : new RestRequest($"companies/{jurisdictionCodeLookup.Jurisdiction}/{jurisdictionCodeLookup.Value}?format=json", Method.GET);
+                ? new RestRequest($"/companies/search?q={nameLookup}", Method.Get) // This will return a sparse company result
+                : new RestRequest($"companies/{jurisdictionCodeLookup.Jurisdiction}/{jurisdictionCodeLookup.Value}?format=json", Method.Get);
 
             request.AddQueryParameter("api_token", openCorporatesExternalSearchJobData.TargetApiKey);
 
@@ -245,10 +244,9 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             IDictionary<string, object> configDict = config.ToDictionary(entry => entry.Key, entry => entry.Value);
             var openCorporatesExternalSearchJobData = new OpenCorporatesExternalSearchJobData(configDict);
 
-            var client = new RestClient("https://api.opencorporates.com/v0.4");
-            client.AddHandler("application/json", () => NewtonsoftJsonSerializer.Default);
+            var client = new RestClient(new RestClientOptions("https://api.opencorporates.com/v0.4"), configureSerialization: s => s.UseSerializer(() => NewtonsoftJsonSerializer.Default));
 
-            var searchCompanyRequest = new RestRequest($"/companies/search?q=Google", Method.GET);
+            var searchCompanyRequest = new RestRequest($"/companies/search?q=Google", Method.Get);
             searchCompanyRequest.AddQueryParameter("api_token", openCorporatesExternalSearchJobData.TargetApiKey);
             var searchCompanyResponse = client.ExecuteAsync<OpenCorporatesResponse>(searchCompanyRequest).Result;
             var searchCompanyTestConnectionResult = ConstructVerifyConnectionResponse(searchCompanyResponse);
@@ -256,14 +254,14 @@ namespace CluedIn.ExternalSearch.Providers.OpenCorporates
             if (!searchCompanyTestConnectionResult.Success)
                 return searchCompanyTestConnectionResult;
 
-            var searchDetailRequest = new RestRequest($"companies/bo/00198057?format=json", Method.GET);
+            var searchDetailRequest = new RestRequest($"companies/bo/00198057?format=json", Method.Get);
             searchDetailRequest.AddQueryParameter("api_token", openCorporatesExternalSearchJobData.TargetApiKey);
             var searchDetailResponse = client.ExecuteAsync<OpenCorporatesResponse>(searchDetailRequest).Result;
 
             return ConstructVerifyConnectionResponse(searchDetailResponse);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.Xunit2"/>
+        <PackageReference Include="AutoFixture.Xunit3"/>
         <PackageReference Include="coverlet.msbuild"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="Moq"/>
         <PackageReference Include="Shouldly"/>


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- RestSharp updated to 114.0.0: `IRestResponse<T>` → `RestResponse<T>`; `Method.GET` → `Method.Get`; `ExecuteTaskAsync` → `ExecuteAsync`; `new Parameter(..., ParameterType.QueryString)` → `new QueryParameter(...)`; `client.BaseUrl` → configured via `RestClientOptions` at construction
- `NewtonsoftJsonSerializer` rewritten to use current RestSharp serializer API